### PR TITLE
Add Gravitee security provider

### DIFF
--- a/gravitee/graviteeio-rest-api/pix-config/gravitee.yml
+++ b/gravitee/graviteeio-rest-api/pix-config/gravitee.yml
@@ -221,7 +221,7 @@ security:
           username: pix-admin # needs to exists to be overriden after
           password:
           roles: DEFAULT
-#    - type: gravitee
+    - type: gravitee
 ## SMTP configuration used to send mails
 email:
   enabled: false


### PR DESCRIPTION
L'utilisateur peut actuellement créer un compte mais pas se loguer.
Il est pourtant bien inseré en base (mongo) et il n'y a pas de message d'erreur particulier (401)

Rajouter le provider gravitee, permet de se logguer par la suite.