### PR TITLE
Disable newsletter by default on first login

### DIFF
--- a/gravitee/graviteeio-rest-api/pix-config/gravitee.yml
+++ b/gravitee/graviteeio-rest-api/pix-config/gravitee.yml
@@ -418,8 +418,8 @@ notifiers:
       # - annotation java.lang.Override
 
 # Allows to enable or disable the 'Subscribe to newsletter' feature when user completes his profile on first log in. Default is enabled.
-#newsletter:
-#  enabled: true
+newsletter:
+  enabled: false
 
 # Specify the visibility duration of a gateway in Unknown State (in seconds)
 # Default : 604800 seconds (7 days)


### PR DESCRIPTION
**Problem:**
When the user first log-in, Gravitee display a modal to subscribe to its newsletter

**solution:**
Do not display the modal by default

**Notes:**
The modal can still be activated via var env:
`gravitee_newsletter_enabled=true`